### PR TITLE
Clarification required for DNSSEC - Can we use BIND DNS server instead?

### DIFF
--- a/doc_source/domain-configure-dnssec.md
+++ b/doc_source/domain-configure-dnssec.md
@@ -5,7 +5,7 @@ Attackers sometimes hijack traffic to internet endpoints such as web servers by 
 You can protect your domain from this type of attack, known as DNS spoofing or a man\-in\-the\-middle attack, by configuring Domain Name System Security Extensions \(DNSSEC\), a protocol for securing DNS traffic\. 
 
 **Important**  
-Amazon Route 53 supports DNSSEC for domain registration\. However, Route 53 does not support DNSSEC for DNS service, regardless of whether the domain is registered with Route 53\. If you want to configure DNSSEC for a domain that is registered with Route 53, you must use another DNS service provider\.
+Amazon Route 53 supports DNSSEC for domain registration\. However, Route 53 does not support DNSSEC for DNS service, regardless of whether the domain is registered with Route 53\. If you want to configure DNSSEC for a domain that is registered with Route 53, you must use another DNS service provider or alternatively, launch a BIND DNS server on an EC2 instance.
 
 **Topics**
 + [Overview of How DNSSEC Protects Your Domain](#domain-configure-dnssec-how-it-works)


### PR DESCRIPTION

*Issue #, if available:* Clarification required for DNSSEC - Can we use BIND DNS server instead?

*Description of changes:*

The article has the following paragraph concerning DNSSEC:

"Amazon Route 53 supports DNSSEC for domain registration. However, Route 53 does not support DNSSEC for DNS service, regardless of whether the domain is registered with Route 53. If you want to configure DNSSEC for a domain that is registered with Route 53, you must use another DNS service provider"

My point of concern is the phrase: "use another DNS service provider", which for me, means that I have to use another DNS service other than AWS, such as CloudFlare, Google Cloud DNS or Azure DNS. Regarding this, I would like to confirm with the AWS team if you can just use a BIND DNS server (launched on an EC2 instance) instead of using an external DNS service provider? This way, I will only use a single cloud computing provider, instead of relying on third-party companies like CloudFlare, Google Cloud DNS or Azure DNS in order to support DNSSEC. 

I understand that a BIND DNS server is usually implemented to resolve Route 53 private hosted zones from an on-premises network. I would like to know some clarity on how to properly implement DNSSEC in AWS without having to rely on third-party DNS service providers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
