### PR TITLE
Update DNSLimitations.md

### DIFF
--- a/doc_source/DNSLimitations.md
+++ b/doc_source/DNSLimitations.md
@@ -83,7 +83,7 @@ For information on getting current quotas \(formerly referred to as "limits"\), 
 | Associations between rules and VPCs per AWS Region | 2000 per AWS account [Request a higher quota](https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/route53/quotas)\.  | 
 | Queries per second per IP address in an endpoint | 10,000\* | 
 
-**\*** The number of DNS queries per second varies by the type of query, the size of response, and the protocol in use\. For information about how to view Amazon CloudWatch metrics for IP addresses for inbound and outbound endpoints, see [Metrics for Resolver IP addresses](monitoring-resolver-with-cloudwatch.md#cloudwatch-metrics-resolver-ip-address)\. Also, this limit of 10,000 QPS is on a per elastic network interface basis. For example, 2 ENIs, which would give 20,000 qps. From there you can scale out by adding more ENIs.
+**\*** The number of DNS queries per second \(QPS\) varies by the type of query, the size of the response, and the protocol in use\. This limit is on a per elastic network interface \(ENI\) basis\. For example, with a limit of 10,000 QPS, 2 ENIs would allow 20,000 QPS\. From there you can scale out by adding more ENIs\. For information about how to view Amazon CloudWatch metrics for IP addresses for inbound and outbound endpoints, see [Metrics for Resolver IP addresses](monitoring-resolver-with-cloudwatch.md#cloudwatch-metrics-resolver-ip-address)\.
 
 ### Quotas on health checks<a name="limits-api-entities-health-checks"></a>
 

--- a/doc_source/DNSLimitations.md
+++ b/doc_source/DNSLimitations.md
@@ -83,7 +83,7 @@ For information on getting current quotas \(formerly referred to as "limits"\), 
 | Associations between rules and VPCs per AWS Region | 2000 per AWS account [Request a higher quota](https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/route53/quotas)\.  | 
 | Queries per second per IP address in an endpoint | 10,000\* | 
 
-**\*** The number of DNS queries per second varies by the type of query, the size of response, and the protocol in use\. For information about how to view Amazon CloudWatch metrics for IP addresses for inbound and outbound endpoints, see [Metrics for Resolver IP addresses](monitoring-resolver-with-cloudwatch.md#cloudwatch-metrics-resolver-ip-address)\.
+**\*** The number of DNS queries per second varies by the type of query, the size of response, and the protocol in use\. For information about how to view Amazon CloudWatch metrics for IP addresses for inbound and outbound endpoints, see [Metrics for Resolver IP addresses](monitoring-resolver-with-cloudwatch.md#cloudwatch-metrics-resolver-ip-address)\. Also, this limit of 10,000 QPS is on a per elastic network interface basis. For example, 2 ENIs, which would give 20,000 qps. From there you can scale out by adding more ENIs.
 
 ### Quotas on health checks<a name="limits-api-entities-health-checks"></a>
 


### PR DESCRIPTION
Added 2 minor clarification under the 10,000 QPS limit.
1) Added that this is on a per ENI basis. Reference: https://d1.awsstatic.com/whitepapers/hybrid-cloud-dns-options-for-vpc.pdf page #6, first paragraph under Constraints section.
2) Added the scale out criteria based on the same above reference.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
