### PR TITLE
Update resolver-query-logs-format.md

### DIFF
--- a/doc_source/resolver-query-logs-format.md
+++ b/doc_source/resolver-query-logs-format.md
@@ -57,7 +57,7 @@ The list of IDs of the sources the DNS query originated from or passed through\.
 **instance**  
 The ID of the instance that the query originated from\.
 
-**resolver\-endpoint**  
+**resolver\_endpoint**  
 The ID of the resolver endpoint that passes the DNS query to on\-premises DNS servers\.
 
 **firewall\_rule\_group\_id**  


### PR DESCRIPTION
Cx verified that the - should be _ and I verified in my account that it in fact shows as "resolver_endpoint": "rslvr-out-2d1d50a599fc443c8" as an example, just need to get this corrected.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
