### PR TITLE
Update DNSLimitations.md

### DIFF
--- a/doc_source/DNSLimitations.md
+++ b/doc_source/DNSLimitations.md
@@ -127,7 +127,7 @@ Use the following procedure to increase quotas for Route 53 Resolver\.<a name="i
 | Entity | Quota | 
 | --- | --- | 
 |  Number of rule groups associated to a VPC for a single account per AWS Region  |   5  | 
-| Number of DNS Firewall domains in a single Amazon S3 file for a single account per AWS Region | 100,000 [Request a higher quota](#increase-quota-procedure)\. | 
+| Number of DNS Firewall domains in a single Amazon S3 file for a single account per AWS Region | 250,000 [Request a higher quota](#increase-quota-procedure)\. | 
 | Number of DNS Firewall rule groups for a single account per AWS Region | 1,000 [Request a higher quota](#increase-quota-procedure)\. | 
 |  Number of rules within a rule group for a single account account per AWS Region  |  100 [Request a higher quota](#increase-quota-procedure)\.  | 
 |  Number of domain lists for a single account account per AWS Region  |  1000 [Request a higher quota](#increase-quota-procedure)\.  | 


### PR DESCRIPTION
Service Quotas shows 250,000 domains in a file imported from S3 and is also the default quota value.

*Issue #, if available:*

*Description of changes:*
Domain in a file import shows as 250,000 in service quotas not 100,000

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
