### PR TITLE
Update DNSSEC failure metric volumes

### DIFF
--- a/doc_source/monitoring-hosted-zones-with-cloudwatch.md
+++ b/doc_source/monitoring-hosted-zones-with-cloudwatch.md
@@ -26,14 +26,14 @@ Region: Route 53 is a global service\. To get hosted zone metrics, you must spe
 Value is 1 if any object in the hosted zone is in an INTERNAL\_FAILURE state\. Otherwise, value is 0\.  
 Valid statistics: N/A  
 Units: Count  
-Volume: 1 per hosted zone per day  
+Volume: 1 per hosted zone every 4 hours  
 Region: Route 53 is a global service\. To get hosted zone metrics, you must specify US East \(N\. Virginia\) for the Region\.
 
 **DNSSECKeySigningKeysNeedingAction**  
 Number of key signing keys \(KSKs\) that have an ACTION\_NEEDED state \(due to KMS failure\)\.  
 Valid statistics: Sum, SampleCount  
 Units: Count  
-Volume: 1 per hosted zone per day  
+Volume: 1 per hosted zone every 4 hours  
 Region: Route 53 is a global service\. To get hosted zone metrics, you must specify US East \(N\. Virginia\) for the Region\. 
 
 **DNSSECKeySigningKeyMaxNeedingActionAge**  


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update volume for DNSSEC failure metrics from one day to 4 hours. This is based on personal experience with these metrics. For example, here is a graph of `DNSSECInternalFailure` for the last week from one of my hosted zones:

![image](https://user-images.githubusercontent.com/8388785/179675113-4dbe9a22-855f-4e24-b754-3f90fcf77248.png)

I'm mainly making this change to encourage the Route53 docs team to verify the correct values with the dev team, whatever those values are.